### PR TITLE
Fix remote browser CDP routing and proxy issues

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -94,7 +94,10 @@ def send_browser_address() -> None:
         parsed_public = urlparse(cdp_url)
         parsed_ws = urlparse(cdp_ws)
         ws_scheme = "wss" if parsed_public.scheme == "https" else "ws"
-        public_ws = urlunparse((ws_scheme, parsed_public.netloc, parsed_ws.path, "", "", ""))
+        # Prefix ws_path with the public CDP path (e.g. /cdp) so the proxy can route it
+        base_path = parsed_public.path.rstrip('/')
+        full_path = f"{base_path}{parsed_ws.path}" if base_path else parsed_ws.path
+        public_ws = urlunparse((ws_scheme, parsed_public.netloc, full_path, "", "", ""))
     else:
         public_ws = cdp_ws
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -32,13 +32,13 @@ app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 
 BROWSER_COMPOSE_FILE = Path(__file__).parent / 'docker-compose.browser.yaml'
 
-# Separate internal (for health checks) and public (for client access) URLs
-# Internal URLs: used by server.py to check Docker container health
-BROWSER_CDP_INTERNAL_URL = os.environ.get('REMOTE_BROWSER_CDP_INTERNAL_URL', 'http://localhost:9322')
+# Separate internal (for server-side operations) and public (for client access) URLs
+# Internal URLs: used by server.py for all CDP operations (health checks, tab management, etc.)
+BROWSER_CDP_INTERNAL_URL = os.environ.get('REMOTE_BROWSER_CDP_INTERNAL_URL', 'http://localhost:9222')
 BROWSER_NOVNC_INTERNAL_URL = os.environ.get('REMOTE_BROWSER_NOVNC_INTERNAL_URL', 'http://localhost:7900')
 
-# Public URLs: sent to frontend and used by main.py to connect
-BROWSER_CDP_PUBLIC_URL = os.environ.get('REMOTE_BROWSER_CDP_PUBLIC_URL', 'http://localhost:9322')
+# Public URLs: sent to frontend for browser viewer and passed to main.py for WebSocket connections
+BROWSER_CDP_PUBLIC_URL = os.environ.get('REMOTE_BROWSER_CDP_PUBLIC_URL', 'http://localhost:9222')
 BROWSER_NOVNC_PUBLIC_URL = os.environ.get('REMOTE_BROWSER_NOVNC_PUBLIC_URL', 'http://localhost:7900/vnc.html?autoconnect=1&resize=scale')
 
 # Construct health check URLs from internal bases
@@ -64,10 +64,13 @@ def build_ws_url(base_http_url: str, ws_path: str) -> Optional[str]:
         return None
     parsed_base = urlparse(base_http_url)
     hostname = parsed_base.hostname or "localhost"
-    port = parsed_base.port or 9322
+    port = parsed_base.port or 9222
     ws_scheme = "wss" if parsed_base.scheme == "https" else "ws"
     ws_netloc = f"{hostname}:{port}"
-    return urlunparse((ws_scheme, ws_netloc, ws_path, "", "", ""))
+    # Prefix ws_path with the base URL's path (e.g. /cdp) so the proxy can route it
+    base_path = parsed_base.path.rstrip('/')
+    full_path = f"{base_path}{ws_path}" if base_path else ws_path
+    return urlunparse((ws_scheme, ws_netloc, full_path, "", "", ""))
 
 # Global dictionary to track running processes per session
 # session_id -> process object
@@ -171,7 +174,7 @@ def close_all_browser_tabs() -> bool:
     print("[SERVER DEBUG] ========== CLOSING ALL BROWSER TABS ==========", flush=True)
     try:
         # Get list of all pages/tabs
-        list_url = f"{BROWSER_CDP_PUBLIC_URL.rstrip('/')}/json/list"
+        list_url = f"{BROWSER_CDP_INTERNAL_URL.rstrip('/')}/json/list"
         print(f"[SERVER DEBUG] Fetching tab list from: {list_url}", flush=True)
 
         req = urllib_request.Request(list_url, headers=CDP_HTTP_HEADERS)
@@ -188,7 +191,7 @@ def close_all_browser_tabs() -> bool:
                 tab_url = tab.get('url', 'unknown')
                 print(f"[SERVER DEBUG] Closing tab {tab_id}: {tab_url[:80]}", flush=True)
 
-                close_url = f"{BROWSER_CDP_PUBLIC_URL.rstrip('/')}/json/close/{tab_id}"
+                close_url = f"{BROWSER_CDP_INTERNAL_URL.rstrip('/')}/json/close/{tab_id}"
                 try:
                     close_req = urllib_request.Request(close_url, headers=CDP_HTTP_HEADERS)
                     with urllib_request.urlopen(close_req, timeout=5) as close_response:
@@ -217,9 +220,9 @@ def close_all_nonblanks(non_blank_tabs) -> None:
         tab_url = tab.get('url', '')
         print(f"[SERVER DEBUG] Closing non-blank tab {tab_id}: {tab_url[:60]}", flush=True)
 
-        close_url = f"{BROWSER_CDP_PUBLIC_URL.rstrip('/')}/json/close/{tab_id}"
+        close_url = f"{BROWSER_CDP_INTERNAL_URL.rstrip('/')}/json/close/{tab_id}"
         try:
-            req = urllib_request.Request(close_url, method='GET')
+            req = urllib_request.Request(close_url, method='GET', headers=CDP_HTTP_HEADERS)
             with urllib_request.urlopen(req, timeout=2) as close_response:
                 print(f"[SERVER DEBUG] ✓ Closed non-blank tab {tab_id}", flush=True)
         except Exception as e:
@@ -231,9 +234,9 @@ def keep_single_blank_tab(blank_tabs) -> None:
         tabs_to_close = blank_tabs[1:]  # Keep first, close rest
         for tab in tabs_to_close:
             tab_id = tab.get('id')
-            close_url = f"{BROWSER_CDP_PUBLIC_URL.rstrip('/')}/json/close/{tab_id}"
+            close_url = f"{BROWSER_CDP_INTERNAL_URL.rstrip('/')}/json/close/{tab_id}"
             try:
-                req = urllib_request.Request(close_url, method='GET')
+                req = urllib_request.Request(close_url, method='GET', headers=CDP_HTTP_HEADERS)
                 with urllib_request.urlopen(req, timeout=2) as close_response:
                     print(f"[SERVER DEBUG] ✓ Closed extra blank tab {tab_id}", flush=True)
             except Exception as e:
@@ -256,7 +259,7 @@ def reset_browser_session() -> bool:
     for attempt in range(max_attempts):
         try:
             # Get list of all pages/tabs with timeout
-            list_url = f"{BROWSER_CDP_PUBLIC_URL.rstrip('/')}/json/list"
+            list_url = f"{BROWSER_CDP_INTERNAL_URL.rstrip('/')}/json/list"
             print(f"[SERVER DEBUG] Fetching tab list from: {list_url} (attempt {attempt + 1}/{max_attempts})", flush=True)
 
             req = urllib_request.Request(list_url, headers=CDP_HTTP_HEADERS)
@@ -282,7 +285,7 @@ def reset_browser_session() -> bool:
                 print(f"[SERVER DEBUG] No blank tabs found, creating one...", flush=True)
                 time.sleep(0.2)  # Brief pause
 
-                new_tab_url = f"{BROWSER_CDP_PUBLIC_URL.rstrip('/')}/json/new"
+                new_tab_url = f"{BROWSER_CDP_INTERNAL_URL.rstrip('/')}/json/new"
                 req = urllib_request.Request(new_tab_url, method='PUT', headers=CDP_HTTP_HEADERS)
                 with urllib_request.urlopen(req, timeout=3) as response:
                     if 200 <= response.status < 300:

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -19,7 +19,7 @@ services:
       REMOTE_BROWSER_CDP_INTERNAL_URL: http://remote-browser:9222
       REMOTE_BROWSER_CDP_PUBLIC_URL: https://platoscave.matheus.wiki/cdp
       REMOTE_BROWSER_NOVNC_INTERNAL_URL: http://remote-browser:7900
-      REMOTE_BROWSER_NOVNC_PUBLIC_URL: https://platoscave.matheus.wiki/vnc/vnc.html?autoconnect=1&resize=scale
+      REMOTE_BROWSER_NOVNC_PUBLIC_URL: https://platoscave.matheus.wiki/vnc/vnc.html?autoconnect=1&resize=scale&path=vnc/websockify
       BROWSER_USE_API_KEY: <YOUR_BROWSER_USE_API_KEY>
       EXA_API_KEY: <YOUR_EXA_API_KEY>
       SUPPRESS_LOGS: false


### PR DESCRIPTION
## Summary

- **Use internal URLs for server-side CDP operations**: `server.py` was using `BROWSER_CDP_PUBLIC_URL` (`https://platoscave.matheus.wiki/cdp`) for internal tab management (list, close, create), causing requests to loop through the external nginx proxy and fail with 403/500 errors. Switched to `BROWSER_CDP_INTERNAL_URL` (`http://remote-browser:9222`).

- **Add missing `Host: localhost` headers**: Chrome rejects CDP requests where the Host header isn't `localhost` or an IP. Two functions (`close_all_nonblanks`, `keep_single_blank_tab`) were missing this header, resulting in `500: Host header is specified and is not an IP address or localhost`.

- **Fix WebSocket URL path prefix**: The public WebSocket URL was missing the `/cdp` prefix (e.g. `wss://platoscave.matheus.wiki/devtools/browser/<id>` instead of `wss://platoscave.matheus.wiki/cdp/devtools/browser/<id>`), causing it to route to the frontend instead of the CDP proxy.

- **Fix noVNC iframe websockify path**: noVNC defaults its WebSocket connection to `/websockify`, but behind the `/vnc/` nginx proxy it needs `path=vnc/websockify` to route correctly. Without this, the WebSocket hit the root location which returned `X-Frame-Options: DENY`.

## Test plan

- [ ] Deploy and verify CDP tab management works (reset browser session on disconnect)
- [ ] Verify browser viewer iframe loads without X-Frame-Options errors
- [ ] Verify WebSocket connection to CDP works through the proxy
- [ ] Run an analysis with browser verification enabled and confirm the remote browser is visible